### PR TITLE
[No Recommended] Fully hide recommended posts without breaking J/K scrolling

### DIFF
--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,5 +1,5 @@
 //* TITLE No Recommended **//
-//* VERSION 2.3.3 **//
+//* VERSION 2.3.4 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -37,14 +37,11 @@ XKit.extensions.norecommended = new Object({
 
 		if (XKit.page.react) {
 			XKit.tools.add_css(`
-				.norecommended-note {
-					height: 1em;
-					color: var(--white-on-dark);
-					opacity: 0.4;
-					padding: var(--post-header-vertical-padding) var(--post-padding);
-				}
-				.norecommended-note ~ * {
-					display: none;
+				.norecommended-hidden,
+ 				.norecommended-hidden + :not(.norecommended-done) {
+					height: 0;
+					margin: 0;
+					overflow: hidden;
 				}
 			`, 'norecommended');
 			XKit.post_listener.add('norecommended', this.react_do);
@@ -69,7 +66,7 @@ XKit.extensions.norecommended = new Object({
 				const is_pinned = loggingReason.startsWith('pin:');
 
 				if ((no_search.value && is_search) || (no_pinned.value && is_pinned) || (!is_search && !is_pinned)) {
-					$this.prepend('<div class="norecommended-note">Hidden by No Recommended</div>');
+					$this.addClass('norecommended-hidden');
 				}
 			}
 		});
@@ -85,7 +82,7 @@ XKit.extensions.norecommended = new Object({
 	destroy: function() {
 		this.running = false;
 		$('.norecommended-done').removeClass('norecommended-done');
-		$('.norecommended-note').remove();
+		$('.norecommended-hidden').removeClass('norecommended-hidden');
 		XKit.post_listener.remove('norecommended');
 		XKit.tools.remove_css("norecommended");
 	}


### PR DESCRIPTION
Not sure why some recommended posts have those non-post spacing elements after them, or if that's the best CSS to match them, but it works on my end at least.